### PR TITLE
A: zippingcare.com

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty_international.txt
+++ b/easyprivacy/easyprivacy_thirdparty_international.txt
@@ -910,6 +910,7 @@
 ||tracker.thinkindot.com^
 ||tracking.smartmeapp.com^
 ||webpixel.smartmeapp.com^
+||zippingcare.com/beacon/$third-party,image
 ! Swedish
 ||aftonbladet.se/blogportal/view/statistics?$third-party
 ||collector.schibsted.io^


### PR DESCRIPTION
These are used by, at least, Simyo (an Spanish internet service provider owned by Orange) to track opened/read emails.

An example is: https://simyo.zippingcare.com/beacon/5ed52b2ae21b840001fd9d35.gif